### PR TITLE
Implement PKCE auth flow

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,7 +1,10 @@
 // app/_layout.tsx
 import { Slot, usePathname, useRouter } from 'expo-router';
 import { useEffect } from 'react';
+import * as WebBrowser from 'expo-web-browser';
 import { AuthProvider, useAuth } from '../src/features/auth';
+
+WebBrowser.maybeCompleteAuthSession();
 
 function ProtectedRoutes() {
   const { session, isLoading } = useAuth();

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -1,5 +1,5 @@
-import Constants from 'expo-constants';
 import { router } from 'expo-router';
+import * as AuthSession from 'expo-auth-session';
 import { useEffect, useState } from 'react';
 import { ActivityIndicator, Button, Text, View } from 'react-native';
 import { supabase } from '../src/shared/lib/supabase';
@@ -26,7 +26,7 @@ export default function LoginScreen() {
     await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo: `${Constants.linkingUri}`,
+        redirectTo: AuthSession.makeRedirectUri({ scheme: 'aidengpt' }),
         queryParams: {
           prompt: 'select_account',
         },

--- a/src/shared/lib/supabase/index.ts
+++ b/src/shared/lib/supabase/index.ts
@@ -1,6 +1,15 @@
 // src/lib/supabase/index.ts
+import 'react-native-url-polyfill/auto';
 import { createClient } from '@supabase/supabase-js';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { SUPABASE } from '../constants';
 
 // Create and export the Supabase client
-export const supabase = createClient(SUPABASE.URL, SUPABASE.ANON_KEY);
+export const supabase = createClient(SUPABASE.URL, SUPABASE.ANON_KEY, {
+  auth: {
+    storage: AsyncStorage,
+    flowType: 'pkce',
+    persistSession: true,
+    detectSessionInUrl: false,
+  },
+});


### PR DESCRIPTION
## Summary
- configure Supabase client for PKCE auth with AsyncStorage
- finalize OAuth flow on launch using `WebBrowser.maybeCompleteAuthSession()`
- update login redirect to use `AuthSession.makeRedirectUri`

## Testing
- `npm run lint` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68839b224bac8323b92deccc2f3ed544